### PR TITLE
Modify Dockerfile to install python36 instead of python34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ ENV LANG=en_US.UTF-8 \
 RUN useradd coreapi
 
 RUN yum --setopt=tsflags=nodocs install -y epel-release && \
-    yum --setopt=tsflags=nodocs install -y gcc python34-pip git wget python34-devel libxml2-devel libxslt-devel python34-pycurl && \
+    yum --setopt=tsflags=nodocs install -y gcc python36-pip git wget python36-devel libxml2-devel libxslt-devel python36-pycurl && \
     yum clean all
 
 # Cache dependencies
 COPY requirements.txt /tmp/
-RUN pip3.4 install --upgrade pip && pip install --upgrade wheel && \
-    pip3.4 install -r /tmp/requirements.txt && \
-    pip3.4 install git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@${F8A_WORKER_VERSION}
+RUN pip3 install --upgrade pip && pip install --upgrade wheel && \
+    pip3 install -r /tmp/requirements.txt && \
+    pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@${F8A_WORKER_VERSION}
 
 ENV APP_DIR=/release_monitor
 RUN mkdir -p ${APP_DIR}
@@ -24,4 +24,4 @@ COPY . .
 
 USER coreapi
 
-CMD ["python3.4", "run.py"]
+CMD ["python3", "run.py"]


### PR DESCRIPTION
- Due to, DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429)